### PR TITLE
Shift+Click/Rightclick to zoom in/out on the skilltree viewer

### DIFF
--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -67,14 +67,14 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 	for id, event in ipairs(inputEvents) do
 		if event.type == "KeyDown" then
 			if event.key == "LEFTBUTTON" then
-				if IsKeyDown("SHIFT") then
+				if IsKeyDown("CTRL") then
 					self:Zoom(2, viewPort)
 				elseif mOver then
 					-- Record starting coords of mouse drag
 					-- Dragging won't actually commence unless the cursor moves far enough
 					self.dragX, self.dragY = cursorX, cursorY
 				end
-			elseif event.key == "RIGHTBUTTON" and IsKeyDown("SHIFT") then
+			elseif event.key == "RIGHTBUTTON" and IsKeyDown("CTRL") then
 				self:Zoom(-2, viewPort)
 			elseif event.key == "p" then
 				self.showHeatMap = not self.showHeatMap

--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -67,11 +67,15 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 	for id, event in ipairs(inputEvents) do
 		if event.type == "KeyDown" then
 			if event.key == "LEFTBUTTON" then
-				if mOver then
+				if IsKeyDown("SHIFT") then
+					self:Zoom(2, viewPort)
+				elseif mOver then
 					-- Record starting coords of mouse drag
 					-- Dragging won't actually commence unless the cursor moves far enough
 					self.dragX, self.dragY = cursorX, cursorY
 				end
+			elseif event.key == "RIGHTBUTTON" and IsKeyDown("SHIFT") then
+				self:Zoom(-2, viewPort)
 			elseif event.key == "p" then
 				self.showHeatMap = not self.showHeatMap
 			end


### PR DESCRIPTION
I've added this on my install for a few versions because my scroll wheel is busted. Doesn't seem to break anything.