### PR TITLE
Optimisation for PassiveTreeView: cache the search results.

### DIFF
--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -28,6 +28,7 @@ local PassiveTreeViewClass = common.NewClass("PassiveTreeView", function(self)
 	self.zoomY = 0
 
 	self.searchStr = ""
+	self.searchStrCached = ""
 	self.showStatDifferences = true
 end)
 
@@ -330,6 +331,14 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 		build.calcsTab:BuildPower()
 	end
 
+	-- Update cached node data
+	if self.searchStrCached ~= self.searchStr then
+		self.searchStrCached = self.searchStr
+		for nodeId, node in pairs(spec.nodes) do
+			node.matchesSearchStr = #self.searchStr > 0 and self:DoesNodeMatchSearchStr(node)
+		end
+	end
+
 	-- Draw the nodes
 	for nodeId, node in pairs(spec.nodes) do
 		-- Determine the base and overlay images for this node based on type and state
@@ -440,7 +449,7 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 			self:DrawAsset(tree.assets[overlay], scrX, scrY, scale)
 			SetDrawColor(1, 1, 1)
 		end
-		if #self.searchStr > 0 and self:DoesNodeMatchSearchStr(node) then
+		if node.matchesSearchStr then
 			-- Node matches the search string, show the highlight circle
 			SetDrawLayer(nil, 30)
 			SetDrawColor(1, 0, 0)


### PR DESCRIPTION
Simple but effective optimisation for the PassiveTreeView, caching the search results saves several thousand calls of string.match() which were quite expensive.

Storing the previous string used isn't the neatest solution but I think it's the most error resistant. Alternatives include:

- A boolean searchStrNeedsChecking, which requires the anyone who sets searchStr to set that too.
- The same flag with a SetSearchStr(str) function to set it for you, but you'd still need to remember to call the setter instead of setting it directly (Lua doesn't do private variables).
- Use the function above and iterate over the nodes in that function rather than doing it later, which risks multiple calls in the same frame causing spikes, and you'd probably still have to store the string somewhere so you can save/load it so it has the same problem as the above.

Attempt 2: Now with more dev and less commits!
