### PR TITLE
Create correct directory when first run and downloading initial skilltrees

### DIFF
--- a/Classes/PassiveTree.lua
+++ b/Classes/PassiveTree.lua
@@ -36,7 +36,7 @@ end
 local PassiveTreeClass = common.NewClass("PassiveTree", function(self, targetVersion)
 	self.targetVersion = targetVersion
 
-	MakeDir("TreeData")
+	MakeDir("TreeData/"..targetVersion)
 
 	ConPrintf("Loading passive tree data...")
 	local treeText


### PR DESCRIPTION
When intially running a dev version of PathOfBuilding it can't download the initial skilltrees as the subdirs 3_0 and 2_6 aren't created, this patch should fix that. We happened upon it in #28. Please do tell if there's something else that should be included!