### PR TITLE
Fixed typo in bereks pass variant identifier

### DIFF
--- a/Data/Uniques/ring.lua
+++ b/Data/Uniques/ring.lua
@@ -36,7 +36,7 @@ League: Domination, Nemesis
 Requires Level 20
 +(12-16)% to Fire and Cold Resistances
 {variant:1}(10-15)% increased Fire Damage
-{variant:1}(25-30)% increased Fire Damage
+{variant:2}(25-30)% increased Fire Damage
 {variant:1}Adds 1 to (10-30) Cold Damage to Attacks
 {variant:2}Adds (20-25) to (30-50) Cold Damage to Spells and Attacks
 +(30-40) to maximum Energy Shield


### PR DESCRIPTION
Resulting in not displaying inc fire damage for variant 2. Closes #673