### PR TITLE
Support Hierophant nodes: Arcane Blessing/Illuminated Devotion

### DIFF
--- a/Data/3_0/Skills/sup_int.lua
+++ b/Data/3_0/Skills/sup_int.lua
@@ -149,15 +149,16 @@ skills["SupportArcaneSurge"] = {
 	baseMods = {
 		mod("ManaCost", "MORE", 10), 
 		--"support_arcane_surge_base_duration_ms" = 4000
+		flag("Condition:UsingArcaneSurgeSupport", { type = "Condition", var = "GainArcaneSurge" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Arcane Surge" }), 
 	},
 	qualityMods = {
 		mod("Damage", "INC", 0.5, ModFlag.Spell, 0, nil), --"spell_damage_+%" = 0.5
 	},
 	levelMods = {
 		[1] = nil, 
-		[2] = mod("Damage", "MORE", nil, ModFlag.Spell, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Arcane Surge" }), --"support_arcane_surge_spell_damage_+%_final"
-		[3] = mod("Speed", "INC", nil, ModFlag.Cast, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Arcane Surge" }), --"support_arcane_surge_cast_speed_+%"
-		[4] = mod("ManaRegenPercent", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Arcane Surge" }), --"support_arcane_surge_mana_regeneration_rate_per_minute_%"
+		[2] = mod("Damage", "MORE", nil, ModFlag.Spell, 0, { type = "Condition", var = "GainArcaneSurge" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Arcane Surge" }), --"support_arcane_surge_spell_damage_+%_final"
+		[3] = mod("Speed", "INC", nil, ModFlag.Cast, 0, { type = "Condition", var = "GainArcaneSurge" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Arcane Surge" }), --"support_arcane_surge_cast_speed_+%"
+		[4] = mod("ManaRegenPercent", "BASE", nil, 0, 0, { type = "Condition", var = "GainArcaneSurge" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Arcane Surge" }), --"support_arcane_surge_mana_regeneration_rate_per_minute_%"
 		--[5] = "support_arcane_surge_gain_buff_on_mana_use_threshold"
 	},
 	levels = {

--- a/Export/Skills/statmap.ini
+++ b/Export/Skills/statmap.ini
@@ -822,12 +822,12 @@ mod = mod("LightningDamage", "MORE", {val}, ModFlag.Spell, 0, { type = "GlobalEf
 mod = mod("Damage", "MORE", {val})
 # Arcane Surge
 [support_arcane_surge_cast_speed_+%]
-mod = mod("Speed", "INC", {val}, ModFlag.Cast, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Arcane Surge" })
+mod = mod("Speed", "INC", {val}, ModFlag.Cast, 0, { type = "Condition", var = "GainArcaneSurge" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Arcane Surge" })
 [support_arcane_surge_mana_regeneration_rate_per_minute_%]
-mod = mod("ManaRegenPercent", "BASE", {val}, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Arcane Surge" })
+mod = mod("ManaRegenPercent", "BASE", {val}, 0, 0, { type = "Condition", var = "GainArcaneSurge" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Arcane Surge" })
 div = 60
 [support_arcane_surge_spell_damage_+%_final]
-mod = mod("Damage", "MORE", {val}, ModFlag.Spell, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Arcane Surge" })
+mod = mod("Damage", "MORE", {val}, ModFlag.Spell, 0, { type = "Condition", var = "GainArcaneSurge" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Arcane Surge" })
 # Bloodlust
 [support_bloodlust_melee_physical_damage_+%_final_vs_bleeding_enemies]
 mod = mod("PhysicalDamage", "MORE", {val}, ModFlag.Melee, 0, { type = "ActorCondition", actor = "enemy", var = "Bleeding" })

--- a/Export/Skills/sup_int.txt
+++ b/Export/Skills/sup_int.txt
@@ -12,6 +12,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportArcaneSurge
+#baseMod flag("Condition:UsingArcaneSurgeSupport", { type = "Condition", var = "GainArcaneSurge" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Arcane Surge" })
 #mods
 
 #skill SupportBlasphemy

--- a/Modules/ConfigOptions.lua
+++ b/Modules/ConfigOptions.lua
@@ -41,6 +41,10 @@ return {
 
 	-- Section: Skill-specific options
 	{ section = "Skill Options", col = 2 },
+	{ label = "Arcane Surge:", ifCond = "GainArcaneSurge" },
+	{ var = "gainArcaneSurge", type = "check", label = "Do you have Arcane Surge?", ifCond = "GainArcaneSurge", apply = function(val, modList, enemyModList)
+			modList:NewMod("Condition:GainArcaneSurge", "FLAG", val, "Config", { type = "Condition", var = "Buffed" })
+	end },
 	{ label = "Aspect of the Avian:", ifSkill = "Aspect of the Avian" },
 	{ var = "aspectOfTheAvianAviansMight", type = "check", label = "Is Avian's Might active?", ifSkill = "Aspect of the Avian", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:AviansMightActive", "FLAG", true, "Config")

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -678,6 +678,7 @@ local modTagList = {
 	["while at maximum power charges"] = { tag = { type = "StatThreshold", stat = "PowerCharges", thresholdStat = "PowerChargesMax" } },
 	["while at maximum frenzy charges"] = { tag = { type = "StatThreshold", stat = "FrenzyCharges", thresholdStat = "FrenzyChargesMax" } },
 	["while at maximum endurance charges"] = { tag = { type = "StatThreshold", stat = "EnduranceCharges", thresholdStat = "EnduranceChargesMax" } },
+	["while you have arcane surge"] = { tag = { type = "Condition", var = "GainArcaneSurge" } },
 	["while you have at least (%d+) crab barriers"] = function(num) return { tag = { type = "StatThreshold", stat = "CrabBarriers", threshold = num } } end,
 	["while you have a totem"] = { tag = { type = "Condition", var = "HaveTotem" } },
 	["while you have fortify"] = { tag = { type = "Condition", var = "Fortify" } },
@@ -948,6 +949,13 @@ local specialModList = {
 	["if you've attacked recently, you and nearby allies have (%d+)%% chance to block attacks"] = function(num) return { mod("ExtraAura", "LIST", { mod = mod("BlockChance", "BASE", num) }, { type = "Condition", var = "AttackedRecently" }) } end,
 	["if you've cast a spell recently, you and nearby allies have (%d+)%% chance to block spells"] = function(num) return { mod("ExtraAura", "LIST", { mod = mod("SpellBlockChance", "BASE", num) }, { type = "Condition", var = "CastSpellRecently" }) } end,
 	-- Hierophant
+	["gain arcane surge when you or your totems hit an enemy with a spell"] = {
+		-- obtain 'Arcane Surge Support' Lv1 effects
+		-- ***When using 'Arcane Surge Support' then these override by gem's effects***
+		mod("Damage", "MORE", 10, nil, ModFlag.Spell, { type = "Condition", var = "UsingArcaneSurgeSupport", neg = true }, { type = "Condition", var = "GainArcaneSurge" }, { type = "GlobalEffect", effectType = "Buff" }),
+		mod("Speed", "INC", 10, nil, ModFlag.Cast, { type = "Condition", var = "UsingArcaneSurgeSupport", neg = true }, { type = "Condition", var = "GainArcaneSurge" }, { type = "GlobalEffect", effectType = "Buff" }),
+		mod("ManaRegenPercent", "BASE", 0.5, nil, 0, { type = "Condition", var = "UsingArcaneSurgeSupport", neg = true }, { type = "Condition", var = "GainArcaneSurge" }, { type = "GlobalEffect", effectType = "Buff" }),
+	},
 	-- Inquisitor
 	["critical strikes ignore enemy monster elemental resistances"] = { flag("IgnoreElementalResistances", { type = "Condition", var = "CriticalStrike" }) },
 	["non%-critical strikes penetrate (%d+)%% of enemy elemental resistances"] = function(num) return { mod("ElementalPenetration", "BASE", num, { type = "Condition", var = "CriticalStrike", neg = true }) } end,


### PR DESCRIPTION
for Issue #868

- Arcane Blessing: Obtain 'Arcane Surge Support' Lv1 effects
  - When using 'Arcane Surge Support' then these override by gem's effects
- Illuminated Devotion: Enable you have Arcane Surge
- Add skill option: `Arcane Surge`