### PR TITLE
support liege of the primordial damage buffs

### DIFF
--- a/Modules/CalcDefence-3_0.lua
+++ b/Modules/CalcDefence-3_0.lua
@@ -616,5 +616,6 @@ function calcs.defence(env, actor)
 		if breakdown then
 			breakdown.LightRadiusMod = breakdown.mod(nil, "LightRadius")
 		end
+		output.SummonedGolem = modDB:Sum("BASE", nil, "Multiplier:SummonedGolem")
 	end
 end

--- a/Modules/CalcSections-3_0.lua
+++ b/Modules/CalcSections-3_0.lua
@@ -946,5 +946,6 @@ return {
 		{ modName = { "StunRecovery", "BlockRecovery" }, }, 
 	}, },
 	{ label = "Light Radius Mod", { format = "x {2:output:LightRadiusMod}", { breakdown = "LightRadiusMod" }, { modName = "LightRadius" }, }, },
+	{ label = "Summoned Golems", { format = "x {1:output:SummonedGolem}", { modName = "Multiplier:SummonedGolem" }, }, },
 } },
 }

--- a/Modules/ConfigOptions.lua
+++ b/Modules/ConfigOptions.lua
@@ -94,6 +94,35 @@ return {
 	{ var = "summonLightningGolemEnableWrath", type = "check", label = "Enable Wrath Aura:", ifSkill = "Summon Lightning Golem", apply = function(val, modList, enemyModList)
 		modList:NewMod("SkillData", "LIST", { key = "enable", value = true }, "Config", { type = "SkillId", skillId = "LightningGolemWrath" })
 	end },
+	{ var = "summonLightningGolemCount", type = "count", label = "# of Lightning Golems:", ifSkill = "Summon Lightning Golem", apply = function(val, modList, enemyModList)
+	    if val >= 0 then
+			modList:NewMod("Multiplier:SummonedGolem", "BASE", val, "Config, # of Lightning Golems")
+		end
+	end },
+	{ var = "summonFlameGolemCount", type = "count", label = "# of Flame Golems:", ifSkill = "Summon Flame Golem", apply = function(val, modList, enemyModList)
+		if val >= 0 then
+			modList:NewMod("Multiplier:SummonedGolem", "BASE", val, "Config, # of Flame Golems")
+		end
+	end },
+	{ var = "summonIceGolemCount", type = "count", label = "# of Ice Golems:", ifSkill = "Summon Ice Golem", apply = function(val, modList, enemyModList)
+		if val >= 0 then
+			modList:NewMod("Multiplier:SummonedGolem", "BASE", val, "Config, # of Ice Golems")
+		end
+	end },
+	{ var = "summonStoneGolemCount", type = "count", label = "# of Stone Golems:", ifSkill = "Summon Stone Golem", apply = function(val, modList, enemyModList)
+		if val >= 0 then
+			modList:NewMod("Multiplier:SummonedGolem", "BASE", val, "Config, # of Stone Golems")
+		end
+	end },
+	{ var = "summonChaosGolemCount", type = "count", label = "# of Chaos Folems:", ifSkill = "Summon Chaos Golem", apply = function(val, modList, enemyModList)
+		if val >= 0 then
+			modList:NewMod("Multiplier:SummonedGolem", "BASE", val, "Config, # of Chaos Golems")
+		end
+	end },
+	{ label = "Aspect of the Crab:", ifSkill = "Aspect of the Crab" },
+	{ var = "overrideCrabBarriers", type = "count", label = "# of Crab Barriers (if not maximum):", ifSkill = "Aspect of the Crab", apply = function(val, modList, enemyModList)
+		modList:NewMod("CrabBarriers", "OVERRIDE", val, "Config", { type = "Condition", var = "Combat" })
+	end },
 	{ label = "Vortex:", ifSkill = "Vortex" },
 	{ var = "vortexCastOnFrostbolt", type = "check", label = "Cast on Frostbolt?", ifSkill = "Vortex", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:CastOnFrostbolt", "FLAG", true, "Config", { type = "SkillName", skillName = "Vortex" })

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -600,6 +600,7 @@ local modTagList = {
 	["per green socket"] = { tag = { type = "Multiplier", var = "GreenSocketIn{SlotName}" } },
 	["per blue socket"] = { tag = { type = "Multiplier", var = "BlueSocketIn{SlotName}" } },
 	["per white socket"] = { tag = { type = "Multiplier", var = "WhiteSocketIn{SlotName}" } },
+	["for each summoned golem"] = { tag = { type = "Multiplier", var = "SummonedGolem" } },
 	-- Per stat
 	["per (%d+) strength"] = function(num) return { tag = { type = "PerStat", stat = "Str", div = num } } end,
 	["per (%d+) dexterity"] = function(num) return { tag = { type = "PerStat", stat = "Dex", div = num } } end,
@@ -918,6 +919,9 @@ local specialModList = {
 		mod("ColdDamageTaken", "INC", -num, { type = "Condition", var = "HitByColdDamageRecently" }), 
 		mod("LightningDamageTaken", "INC", -num, { type = "Condition", var = "HitByLightningDamageRecently" })
 	} end,
+	--["(%d+)%% increased damage for each summoned golem"] = function(num) return {
+	--	mod("Damage", "INC", num, { type = "Multiplier", var = "SummonedGolem" })
+	--} end,
 	["every %d+ seconds:"] = { },
 	["gain chilling conflux for %d seconds"] = { 
 		flag("PhysicalCanChill", { type = "Condition", var = "ChillingConflux" }),


### PR DESCRIPTION
Enable 3.2 liege of the primordial "for each summoned golem" text.
Added to configs amount of summoned golems by type. 
Damage buff and golem buff increase are calculated OK.
I could not make it so number of golems becomes zero if i disable skill. Like Lightning golem aura is disabled when you disable lightning golem skill.
number of golems is not checked against "number of active minions" stat