### PR TITLE
#1233 "None" weapon type check to the DualWielding conditional

### DIFF
--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -106,7 +106,7 @@ local function doActorAttribsPoolsConditions(env, actor)
 			condList["UsingTwoHandedWeapon"] = true
 		end
 	end
-	if actor.weaponData1.type and actor.weaponData2.type then
+	if actor.weaponData1.type and actor.weaponData2.type and actor.weaponData1.type ~= "None" then
 		condList["DualWielding"] = true
 		if actor.weaponData1.type == "Claw" and actor.weaponData2.type == "Claw" then
 			condList["DualWieldingClaws"] = true


### PR DESCRIPTION
A minor change to CalcPerform. Since "None" is the unarmed weapon type, I've added an additional condition for checking that Weapon 1 type does not equal "None". This prevents "None" in Weapon 1 from enabling the DualWielding condition when used together with a weapon in Weapon 2.
Fixes #1233