### PR TITLE
Use SHIFT to hide passive tree tooltips.

### DIFF
--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -473,7 +473,7 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 			local size = 175 * scale / self.zoom ^ 0.4
 			DrawImage(self.highlightRing, scrX - size, scrY - size, size * 2, size * 2)
 		end
-		if node == hoverNode and (node.type ~= "Socket" or not IsKeyDown("SHIFT")) and not main.popups[1] then
+		if node == hoverNode and not IsKeyDown("SHIFT") and not main.popups[1] then
 			-- Draw tooltip
 			SetDrawLayer(nil, 100)
 			local size = m_floor(node.size * scale)


### PR DESCRIPTION
I wanted to see the suggested path when hovering unallocated
nodes, and the tooltips make it difficult.  This change makes
use of the `SHIFT` key which is already in similar use on
jewel nodes.  I tried it out when drawing a path, another
application of `SHIFT` in that context, and I was pleasantly
surprised it let me see what I was drawing out much easier.

There may be some other use of `SHIFT` that makes this change
conflict with a different use pattern.  If so, my second choice
approach might be to have a checkbox at bottom, alongside
`Show Node Power`, which could be labelled "Hide Tooltips."