### PR TITLE
removed cannot be frozen from crystal vault

### DIFF
--- a/Data/Uniques/body.lua
+++ b/Data/Uniques/body.lua
@@ -747,7 +747,6 @@ Requires Level 49
 (140–160)% increased Armour and Energy Shield
 +(50–75)% to Cold Resistance
 Cannot be Chilled
-Cannot be Frozen
 20% of Physical Damage from Hits taken as Cold Damage
 30% of Fire Damage from Hits taken as Cold Damage
 (15–20)% increased Effect of Chill


### PR DESCRIPTION
#1130 

Crystal vault does not have the property 'Cannot be frozen', removed

https://pathofexile.gamepedia.com/Crystal_Vault