### PR TITLE
Add tree node power colouring based on specific stats

### DIFF
--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -341,6 +341,7 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 
 	if self.showHeatMap then
 		-- Build the power numbers if needed
+		self.heatMapStat = build.calcsTab.powerStat
 		build.calcsTab:BuildPower()
 	end
 
@@ -410,18 +411,31 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 		end
 		if self.showHeatMap then
 			if not node.alloc and node.type ~= "ClassStart" and node.type ~= "AscendClassStart" then
-				-- Calculate color based on DPS and defensive powers
-				local offence = m_max(node.power.offence or 0, 0)
-				local defence = m_max(node.power.defence or 0, 0)
-				local dpsCol = (offence / build.calcsTab.powerMax.offence * 1.5) ^ 0.5
-				local defCol = (defence / build.calcsTab.powerMax.defence * 1.5) ^ 0.5
-				local mixCol = (m_max(dpsCol - 0.5, 0) + m_max(defCol - 0.5, 0)) / 2
-				if main.nodePowerTheme == "RED/BLUE" then
-					SetDrawColor(dpsCol, mixCol, defCol)
-				elseif main.nodePowerTheme == "RED/GREEN" then
-					SetDrawColor(dpsCol, defCol, mixCol)
-				elseif main.nodePowerTheme == "GREEN/BLUE" then
-					SetDrawColor(mixCol, dpsCol, defCol)
+				if self.heatMapStat and self.heatMapStat.stat then
+					-- Calculate color based on a single stat
+					local stat = m_max(node.power.singleStat or 0, 0)
+					local statCol = (stat / build.calcsTab.powerMax.singleStat * 1.5) ^ 0.5
+					if main.nodePowerTheme == "RED/BLUE" then
+						SetDrawColor(0, statCol, 0)
+					elseif main.nodePowerTheme == "RED/GREEN" then
+						SetDrawColor(0, 0, statCol)
+					elseif main.nodePowerTheme == "GREEN/BLUE" then
+						SetDrawColor(statCol, 0, 0)
+					end
+				else
+					-- Calculate color based on DPS and defensive powers
+					local offence = m_max(node.power.offence or 0, 0)
+					local defence = m_max(node.power.defence or 0, 0)
+					local dpsCol = (offence / build.calcsTab.powerMax.offence * 1.5) ^ 0.5
+					local defCol = (defence / build.calcsTab.powerMax.defence * 1.5) ^ 0.5
+					local mixCol = (m_max(dpsCol - 0.5, 0) + m_max(defCol - 0.5, 0)) / 2
+					if main.nodePowerTheme == "RED/BLUE" then
+						SetDrawColor(dpsCol, mixCol, defCol)
+					elseif main.nodePowerTheme == "RED/GREEN" then
+						SetDrawColor(dpsCol, defCol, mixCol)
+					elseif main.nodePowerTheme == "GREEN/BLUE" then
+						SetDrawColor(mixCol, dpsCol, defCol)
+					end
 				end
 			else
 				SetDrawColor(1, 1, 1)

--- a/Classes/TreeTab.lua
+++ b/Classes/TreeTab.lua
@@ -85,6 +85,9 @@ local TreeTabClass = common.NewClass("TreeTab", "ControlHost", function(self, bu
 	self.controls.treeHeatMap = common.New("CheckBoxControl", {"LEFT",self.controls.treeSearch,"RIGHT"}, 130, 0, 20, "Show Node Power:", function(state)	
 		self.viewer.showHeatMap = state
 	end)
+	self.controls.treeHeatMapStatSelect = common.New("DropDownControl", {"LEFT",self.controls.treeHeatMap,"RIGHT"}, 8, 0, 150, 20, nil, function(index, value)
+		self:SetPowerCalc(self.build.calcsTab.powerStatList[index])
+	end)
 	self.controls.treeHeatMap.tooltipText = function()
 		local offCol, defCol = main.nodePowerTheme:match("(%a+)/(%a+)")
 		return "When enabled, an estimate of the offensive and defensive strength of\neach unallocated passive is calculated and displayed visually.\nOffensive power shows as "..offCol:lower()..", defensive power as "..defCol:lower().."."
@@ -121,10 +124,21 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 		t_insert(self.controls.specSelect.list, spec.title or "Default")
 	end
 	t_insert(self.controls.specSelect.list, "Manage trees...")
+
 	if not self.controls.treeSearch.hasFocus then
 		self.controls.treeSearch:SetText(self.viewer.searchStr)
 	end
+
 	self.controls.treeHeatMap.state = self.viewer.showHeatMap
+
+	self.controls.treeHeatMapStatSelect.selIndex = 1
+	wipeTable(self.controls.treeHeatMapStatSelect.list)
+	for id, stat in ipairs(self.build.calcsTab.powerStatList) do
+		t_insert(self.controls.treeHeatMapStatSelect.list, stat.title or stat.stat)
+		if self.build.calcsTab.powerStat and self.build.calcsTab.powerStat.stat == stat.stat then
+			self.controls.treeHeatMapStatSelect.selIndex = id
+		end
+	end
 
 	SetDrawLayer(1)
 
@@ -211,6 +225,15 @@ function TreeTabClass:SetActiveSpec(specId)
 		-- Update item slots if items have been loaded already
 		self.build.itemsTab:PopulateSlots()
 	end
+end
+
+function TreeTabClass:SetPowerCalc(selection)
+	self.viewer.showHeatMap = true
+	self.build.buildFlag = true
+	self.build.powerBuildFlag = true
+	self.build.calcsTab.powerStat = selection
+	-- self.viewer.heatMapStat = self.build.calcsTab.powerStat
+	self.build.calcsTab:BuildPower()
 end
 
 function TreeTabClass:OpenSpecManagePopup()


### PR DESCRIPTION
Extends the passive tree's Node Power feature to allow colouring based on the effects on a single stat.
There is currently a small list of suitable stats (see screenshot). Others could be added, but the UI is limited and some stats will need conversions to be specified.

I have no plans currently to make the list of stats user-customisable.

![image](https://user-images.githubusercontent.com/28345893/49055117-5bd50e00-f1ee-11e8-82b5-3f13ba6774e0.png)
