### PR TITLE
Update TreeTab.lua

### DIFF
--- a/Classes/TreeTab.lua
+++ b/Classes/TreeTab.lua
@@ -282,7 +282,7 @@ function TreeTabClass:OpenImportPopup()
 end
 
 function TreeTabClass:OpenExportPopup()
-	local treeLink = self.build.spec:EncodeURL("https://www.pathofexile.com/passive-skill-tree/"..(self.build.targetVersion == "2_6" and "2.6.2/" or "3.4.0/"))
+	local treeLink = self.build.spec:EncodeURL("https://www.pathofexile.com/passive-skill-tree/")
 	local popup
 	local controls = { }
 	controls.label = new("LabelControl", nil, 0, 20, 0, 16, "Passive tree link:")


### PR DESCRIPTION
Eliminated the Version Number from the tree export so it always links to the most recent tree on the webseite. Old trees are never supported and being deleted fast, making a link to an obsolete version useless.