### PR TITLE
Fix Scourge Arrow's Thorn Arrows DPS

### DIFF
--- a/Data/3_0/Skills/act_dex.lua
+++ b/Data/3_0/Skills/act_dex.lua
@@ -5034,7 +5034,7 @@ skills["ScourgeArrow"] = {
 	},
 	baseMods = {
 		mod("Multiplier:ScourgeArrowStage", "BASE", 5, 0, 0, { type = "SkillPart", skillPartList = { 2, 3 } }),
-		skill("dpsMultiplier", 0.2, { type = "SkillPart", skillPart = 2 }),
+		skill("dpsMultiplier", 0.2, { type = "SkillPart", skillPartList = { 2, 3 } }),
 	},
 	qualityStats = {
 		{ "base_projectile_speed_+%", 1 },

--- a/Export/Skills/act_dex.txt
+++ b/Export/Skills/act_dex.txt
@@ -784,7 +784,7 @@ local skills, mod, flag, skill = ...
 		},
 	},
 #baseMod mod("Multiplier:ScourgeArrowStage", "BASE", 5, 0, 0, { type = "SkillPart", skillPartList = { 2, 3 } })
-#baseMod skill("dpsMultiplier", 0.2, { type = "SkillPart", skillPart = 2 })
+#baseMod skill("dpsMultiplier", 0.2, { type = "SkillPart", skillPartList = { 2, 3 } })
 #mods
 
 #skill ShatteringSteel


### PR DESCRIPTION
- Added 0.2 DPS multiplier to Scourge Arrow's Thorns (DPS calculated at 5 stages)

This closes #1396 