### PR TITLE
Support for updated Inquisitor Ascendancy node: Sanctuary 

### DIFF
--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1063,7 +1063,7 @@ local specialModList = {
 	-- Inquisitor
 	["critical strikes ignore enemy monster elemental resistances"] = { flag("IgnoreElementalResistances", { type = "Condition", var = "CriticalStrike" }) },
 	["non%-critical strikes penetrate (%d+)%% of enemy elemental resistances"] = function(num) return { mod("ElementalPenetration", "BASE", num, { type = "Condition", var = "CriticalStrike", neg = true }) } end,
-	["consecrated ground you create grants (%d+)%% increased damage to you and allies"] = function(num) return { mod("Damage", "INC", num, { type = "Condition", var = "OnConsecratedGround" }) } end,
+	["consecrated ground you create applies (%d+)%% increased damage taken to enemies"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("DamageTaken", "INC", num) }) } end,
 	["nearby enemies take (%d+)%% increased elemental damage"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("ElementalDamageTaken", "INC", num) }) } end,
 	-- Juggernaut
 	["armour received from body armour is doubled"] = { flag("Unbreakable") },


### PR DESCRIPTION
In 3.6.0, the Inquisitor Ascendancy node "Sanctify" was renamed "Sanctuary" and reworked. 

This adds support for the new mod "Consecrated Ground you create applies 10% increased Damage taken to Enemies"

From poe wiki:

```
Renamed from Sanctify and reworked.
Old: 
30% chance to create Consecrated Ground when Hit, lasting 8 seconds
30% chance to create Consecrated Ground on Kill, lasting 8 seconds
10% chance to create Consecrated Ground when you Hit a Rare or Unique Enemy, lasting 8 seconds
Consecrated Ground you create grants 40% increased Damage to you and your Allies
```

Now: 

```
You have Consecrated Ground around you while stationary
Consecrated Ground you create applies 10% increased Damage taken to Enemies
15 Mana Regenerated per Second while on Consecrated Ground
```