### PR TITLE
Resolve Issue #1544: Lua error when overing over stat in calcs tab

### DIFF
--- a/Classes/CalcBreakdownControl.lua
+++ b/Classes/CalcBreakdownControl.lua
@@ -389,7 +389,7 @@ function CalcBreakdownClass:AddModSection(sectionData, modList)
 				elseif tag.type == "MultiplierThreshold" or tag.type == "StatThreshold" then
 					desc = "If "..self:FormatVarNameOrList(tag.var or tag.stat, tag.varList or tag.statList)..(tag.upper and " <= " or " >= ")..(tag.threshold or self:FormatModName(tag.thresholdVar or tag.thresholdStat))
 				elseif tag.type == "SkillName" then
-					desc = "Skill: "..tag.skillName
+					desc = "Skill: "..(tag.skillName or table.concat(tag.skillNameList, ", "))
 				elseif tag.type == "SkillId" then
 					desc = "Skill: "..build.data.skills[tag.skillId].name
 				elseif tag.type == "SkillType" then


### PR DESCRIPTION
Resolves #1544 
When generating modifier tag description and that mod criterion is a skill name, it is possible that there is a list of names instead of a single one. E.g. Fast and Deadly affects both Blink Arrow and Mirror Arrow.