### PR TITLE
Modify Export Tree to use defaults

### DIFF
--- a/Classes/TreeTab.lua
+++ b/Classes/TreeTab.lua
@@ -305,7 +305,7 @@ function TreeTabClass:OpenImportPopup()
 end
 
 function TreeTabClass:OpenExportPopup()
-	local treeLink = self.build.spec:EncodeURL("https://www.pathofexile.com/passive-skill-tree/"..(self.build.targetVersion == "2_6" and "2.6.2/" or "3.6.0/"))
+	local treeLink = self.build.spec:EncodeURL("https://www.pathofexile.com/fullscreen-passive-skill-tree/")
 	local popup
 	local controls = { }
 	controls.label = new("LabelControl", nil, 0, 20, 0, 16, "Passive tree link:")


### PR DESCRIPTION
This changes using the static version which would need to be updated every PoE release to leverage PoE's skill tree API (which uses the latest version).

This also uses the fullscreen passive tree.

Resolves:
#1311
#1196