### PR TITLE
Items tab: sorting crafted item modifiers alphabetically

### DIFF
--- a/Classes/ItemsTab.lua
+++ b/Classes/ItemsTab.lua
@@ -1568,6 +1568,23 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 					})
 				end
 			end
+
+            -- Sorts modifiers by label
+            -- Ignores the initial magnitude part
+            -- Ex: "+10% ham" comes after "Gummybears"
+            table.sort(modList, function comparator(l, r)
+                local l_first_letter_index = string.find(l.label, "[%u%l]")
+                local r_first_letter_index = string.find(r.label, "[%u%l]")
+
+                local lthunk = string.lower(string.sub(l.label, l_first_letter_index))
+                local rthunk = string.lower(string.sub(r.label, r_first_letter_index))
+
+                if lthunk < rthunk then
+                    return true
+                else
+                    return false
+                end
+            end)
 		elseif sourceId == "ESSENCE" then
 			for _, essence in pairs(self.build.data.essences) do
 				local modId = essence.mods[self.displayItem.type]

--- a/Classes/ItemsTab.lua
+++ b/Classes/ItemsTab.lua
@@ -1569,22 +1569,22 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 				end
 			end
 
-            -- Sorts modifiers by label
-            -- Ignores the initial magnitude part
-            -- Ex: "+10% ham" comes after "Gummybears"
-            table.sort(modList, function comparator(l, r)
-                local l_first_letter_index = string.find(l.label, "[%u%l]")
-                local r_first_letter_index = string.find(r.label, "[%u%l]")
+			-- Sorts modifiers by label
+			-- Ignores the initial magnitude part
+			-- Ex: "+10% ham" comes after "Gummybears"
+			table.sort(modList, function comparator(l, r)
+				local l_first_letter_index = string.find(l.label, "[%u%l]")
+				local r_first_letter_index = string.find(r.label, "[%u%l]")
 
-                local lthunk = string.lower(string.sub(l.label, l_first_letter_index))
-                local rthunk = string.lower(string.sub(r.label, r_first_letter_index))
+				local lthunk = string.lower(string.sub(l.label, l_first_letter_index))
+				local rthunk = string.lower(string.sub(r.label, r_first_letter_index))
 
-                if lthunk < rthunk then
-                    return true
-                else
-                    return false
-                end
-            end)
+				if lthunk < rthunk then
+					return true
+				else
+					return false
+				end
+			end)
 		elseif sourceId == "ESSENCE" then
 			for _, essence in pairs(self.build.data.essences) do
 				local modId = essence.mods[self.displayItem.type]


### PR DESCRIPTION
Hi, I created this patch to sort crafted modifiers by name. The sorting function ignores the inital magnitude part (ex: +10%)
Let me know if anything needs to be done differently.