### PR TITLE
Lucky Hits

### DIFF
--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -1208,7 +1208,11 @@ function calcs.offence(env, actor, activeSkill)
 		output.ManaOnHitRate = output.ManaOnHit * hitRate
 
 		-- Calculate average damage and final DPS
-		output.AverageHit = (totalHitMin + totalHitMax) / 2 * (1 - output.CritChance / 100) + (totalCritMin + totalCritMax) / 2 * output.CritChance / 100
+		if skillModList:Flag(skillCfg, "LuckyHits") then 
+			output.AverageHit = (totalHitMin / 3 + 2 * totalHitMax/ 3) * (1 - output.CritChance / 100) + (totalCritMin / 3 + 2 * totalCritMax / 3) * output.CritChance / 100
+		else
+			output.AverageHit = (totalHitMin + totalHitMax) / 2 * (1 - output.CritChance / 100) + (totalCritMin + totalCritMax) / 2 * output.CritChance / 100
+		
 		output.AverageDamage = output.AverageHit * output.HitChance / 100
 		output.TotalDPS = output.AverageDamage * (globalOutput.HitSpeed or globalOutput.Speed) * (skillData.dpsMultiplier or 1)
 		if breakdown then

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -1209,17 +1209,23 @@ function calcs.offence(env, actor, activeSkill)
 
 		-- Calculate average damage and final DPS
 		if skillModList:Flag(skillCfg, "LuckyHits") then 
-			output.AverageHit = (totalHitMin / 3 + 2 * totalHitMax/ 3) * (1 - output.CritChance / 100) + (totalCritMin / 3 + 2 * totalCritMax / 3) * output.CritChance / 100
+			AverageNonCritHit = (totalHitMin / 3 + 2 * totalHitMax / 3)
+			AverageCritHit = (totalCritMin / 3 + 2 * totalCritMax / 3)
 		else
-			output.AverageHit = (totalHitMin + totalHitMax) / 2 * (1 - output.CritChance / 100) + (totalCritMin + totalCritMax) / 2 * output.CritChance / 100
+			AverageNonCritHit = (totalHitMin / 2 + totalHitMax / 2)
+			AverageCritHit = (totalCritMin / 2 + totalCritMax / 2)
+		end
 		
+		output.AverageHit = AverageNonCritHit * (1 - output.CritChance / 100) + AverageCritHit * output.CritChance / 100
+	
+
 		output.AverageDamage = output.AverageHit * output.HitChance / 100
 		output.TotalDPS = output.AverageDamage * (globalOutput.HitSpeed or globalOutput.Speed) * (skillData.dpsMultiplier or 1)
 		if breakdown then
 			if output.CritEffect ~= 1 then
 				breakdown.AverageHit = {
-					s_format("%.1f x (1 - %.4f) ^8(damage from non-crits)", (totalHitMin + totalHitMax) / 2, output.CritChance / 100),
-					s_format("+ %.1f x %.4f ^8(damage from crits)", (totalCritMin + totalCritMax) / 2, output.CritChance / 100),
+					s_format("%.1f x (1 - %.4f) ^8(damage from non-crits)", AverageNonCritHit, output.CritChance / 100),
+					s_format("+ %.1f x %.4f ^8(damage from crits)", AverageCritHit, output.CritChance / 100),
 					s_format("= %.1f", output.AverageHit),
 				}
 			end

--- a/Modules/CalcSetup.lua
+++ b/Modules/CalcSetup.lua
@@ -56,6 +56,7 @@ function calcs.initModDB(env, modDB)
 	modDB:NewMod("Onslaught", "FLAG", true, "Base", { type = "Condition", var = "Onslaught" })
 	modDB:NewMod("UnholyMight", "FLAG", true, "Base", { type = "Condition", var = "UnholyMight" })
 	modDB:NewMod("Tailwind", "FLAG", true, "Base", { type = "Condition", var = "Tailwind" })
+	modDB:NewMod("LuckyHits", "FLAG", true, "Base", { type = "Condition", var = "LuckyHits" })
 	modDB:NewMod("Adrenaline", "FLAG", true, "Base", { type = "Condition", var = "Adrenaline" })
 	modDB.conditions["Buffed"] = env.mode_buffs
 	modDB.conditions["Combat"] = env.mode_combat

--- a/Modules/ConfigOptions.lua
+++ b/Modules/ConfigOptions.lua
@@ -387,6 +387,9 @@ return {
 	{ var = "buffTailwind", type = "check", label = "Do you have Tailwind?", tooltip = "In addition to allowing any 'while you have Tailwind' modifiers to apply,\nthis will enable the Tailwind buff itself. (You are 10% faster)", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:Tailwind", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
+	{ var = "buffLuckyHits", type = "check", label = "Damage with Hits is Lucky", tooltip = "Damage is rolled twice, maximum roll is used", apply = function(val, modList, enemyModList)
+		modList:NewMod("Condition:LuckyHits", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
+	end },
 	{ var = "buffAdrenaline", type = "check", label = "Do you have Adrenaline?", tooltip = "This will enable the Adrenaline buff:\n100% increased Damage\n25% increased Attack, Cast and Movement Speed\n10% additional Physical Damage Reduction", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:Adrenaline", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },

--- a/Modules/ConfigOptions.lua
+++ b/Modules/ConfigOptions.lua
@@ -388,7 +388,7 @@ return {
 		modList:NewMod("Condition:Tailwind", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
 	{ var = "buffLuckyHits", type = "check", label = "Damage with Hits is Lucky", tooltip = "Damage is rolled twice, maximum roll is used", apply = function(val, modList, enemyModList)
-		modList:NewMod("Condition:LuckyHits", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
+		modList:NewMod("LuckyHits", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
 	{ var = "buffAdrenaline", type = "check", label = "Do you have Adrenaline?", tooltip = "This will enable the Adrenaline buff:\n100% increased Damage\n25% increased Attack, Cast and Movement Speed\n10% additional Physical Damage Reduction", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:Adrenaline", "FLAG", true, "Config", { type = "Condition", var = "Combat" })


### PR DESCRIPTION
Added in the following:
- Checkbox `Damage with Hits is Lucky` with tooltip `Damage is rolled twice, maximum roll is used`
- Added in new Mod `LuckyHits` 
- Incorporated within DamageType loop, adding in variables for average hit damage and averate crit damage within the loop
- Updated formula for lucky hits `(1/3*min + 2/3*max)`
- Updated breakdown 

Have confirmed in dev that 
- Correct dps numbers and tooltip
- Does not affect dots
- Correctly affects leech
- Correctly affects percentage damage calcs in breakdown

Possible extra features:
- Add in support for Dancing with Death/Vaal Arc