### PR TITLE
Added block chance to Bringer of Rain

### DIFF
--- a/Data/Uniques/helmet.lua
+++ b/Data/Uniques/helmet.lua
@@ -513,7 +513,7 @@ Adds 20 to 30 Physical Damage to Attacks
 Extra gore
 Can't use Chest armour
 {variant:1,2}15% Chance to Block
-{variant:3}6% Chance to Block
+{variant:3,4}6% Chance to Block
 ]],[[
 Deidbell
 Gilded Sallet


### PR DESCRIPTION
Current version of Bringer of Rain still has the 6% block chance.