### PR TITLE
Correct mod on Abberath's Hooves.

### DIFF
--- a/Data/Uniques/boots.lua
+++ b/Data/Uniques/boots.lua
@@ -135,7 +135,7 @@ Requires Level 12, 26 Dex
 15% increased Movement Speed
 (6-10)% chance to Ignite
 Ignite a nearby Enemy on Killing an Ignited Enemy
-Casts level 7 Abberath's Fury when equipped
+Triggers level 7 Abberath's Fury when equipped
 1% increased Fire Damage per 20 Strength
 Burning Hoofprints
 ]],[[


### PR DESCRIPTION
Ingame, it says "Triggers" instead of "Casts". Besides, the expected behavior of items that grant abilities in Path of Building is to have an empty nameSpec attribute. In it's current form, this mod breaks some of my code.