### PR TITLE
Correct implicit on all unique Paua Rings.

### DIFF
--- a/Data/Uniques/ring.lua
+++ b/Data/Uniques/ring.lua
@@ -299,7 +299,7 @@ Requires Level 46
 ]],[[
 Doedre's Damning
 Paua Ring
-+(20-25) to maximum Mana
++(20-30) to maximum Mana
 +(5-10) to Intelligence
 +5% to all Elemental Resistances
 +5 Mana Gained on Kill
@@ -566,7 +566,7 @@ Perandus Signet
 Paua Ring
 Variant: Pre 2.0.0
 Variant: Current
-+(20-25) to maximum Mana
++(20-30) to maximum Mana
 +(25-30) to maximum Mana
 (45-65)% increased Mana Regeneration Rate
 {variant:1}3% increased Experience gain
@@ -578,7 +578,7 @@ Variant: Current
 Praxis
 Paua Ring
 Requires Level 22
-+(20-25) to maximum Mana
++(20-30) to maximum Mana
 +(30-60) to maximum Mana
 (3-6) Mana Regenerated per second
 −(4-8) to Mana Cost of Skills


### PR DESCRIPTION
In 3.8.0, the implicit on Paua Rings was changed. While rare Paua Rings are already updated, uniques are not. There is no legacy variant.