### PR TITLE
Updated Star of Wraeclast to 3.8.0

### DIFF
--- a/Data/Uniques/amulet.lua
+++ b/Data/Uniques/amulet.lua
@@ -657,15 +657,18 @@ Star of Wraeclast
 Ruby Amulet
 Source: Vendor recipe
 Variant: Pre 2.6.0
+Variant: Pre 3.8.0
 Variant: Current
 Requires Level 28
+{variant:1,2}Grants level 20 Illusory Warp Skill
+{variant:3}Grants Level 10 Frostblink Skill
 +(20-30)% to Fire Resistance
 (30-50)% increased Cold Damage
 +(10-15)% to all Elemental Resistances
-{variant:1}30% increased Radius of Curse Skills
-{variant:2}60% increased Area of Effect of Curse Skills
+{variant:1}30% increased Area of Effect of Curse Skills
+{variant:2,3}60% increased Area of Effect of Curse Skills
 You are Immune to Silence
-Grants level 20 Illusory Warp Skill
+{variant:3}Frostblink has 50% increased Duration
 Corrupted
 ]],[[
 Stone of Lazhwar


### PR DESCRIPTION
Star of Wraeclast's unique skill Illusory Warp gets replaced by Frostblink in new versions.