### PR TITLE
Updated wording on all staves regarding block chance

### DIFF
--- a/Data/Uniques/staff.lua
+++ b/Data/Uniques/staff.lua
@@ -9,8 +9,8 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 66, 158 Str, 113 Int
 Implicits: 2
-{variant:1}12% Chance to Block
-{variant:2}18% Chance to Block
+{variant:1}12% Chance to Block Attack Damage while wielding a Staff
+{variant:2}18% Chance to Block Attack Damage while wielding a Staff
 {variant:1}+1 to Level of Socketed Lightning Gems
 {variant:2}+2 to Level of Socketed Lightning Gems
 +(80-120) to Intelligence
@@ -25,8 +25,8 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 66, 158 Str, 113 Int
 Implicits: 2
-{variant:1}12% Chance to Block
-{variant:2}18% Chance to Block
+{variant:1}12% Chance to Block Attack Damage while wielding a Staff
+{variant:2}18% Chance to Block Attack Damage while wielding a Staff
 {variant:1}+1 to Level of Socketed Lightning Gems
 {variant:2}+2 to Level of Socketed Lightning Gems
 +(80-120) to Intelligence
@@ -41,8 +41,8 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 66, 158 Str, 113 Int
 Implicits: 2
-{variant:1}12% Chance to Block
-{variant:2}18% Chance to Block
+{variant:1}12% Chance to Block Attack Damage while wielding a Staff
+{variant:2}18% Chance to Block Attack Damage while wielding a Staff
 {variant:1}+1 to Level of Socketed Lightning Gems
 {variant:2}+2 to Level of Socketed Lightning Gems
 +(80-120) to Intelligence
@@ -72,8 +72,8 @@ Gnarled Branch
 Variant: Pre 2.6.0
 Variant: Current
 Implicits: 2
-{variant:1}12% Chance to Block
-{variant:2}18% Chance to Block
+{variant:1}12% Chance to Block Attack Damage while wielding a Staff
+{variant:2}18% Chance to Block Attack Damage while wielding a Staff
 12% Chance to Block
 100% increased Physical Damage
 (5-10)% increased Attack Speed
@@ -85,7 +85,7 @@ Ezomyte Staff
 Variant: Pre 3.5.0
 Variant: Current
 Requires Level: 62
-18% Chance to Block 
+18% Chance to Block Attack Damage while wielding a Staff
 +2 to Level of Socketed Chaos Gems
 {variant:1}(60–80)% increased Chaos Damage
 {variant:2}(20–30)% increased Chaos Damage
@@ -100,7 +100,7 @@ Source: Drops from unique{The Elder} (Uber)
 Variant: Pre 3.7.0
 Variant: Current
 Requires Level 64
-20% Chance to Block
+20% Chance to Block Attack Damage while wielding a Staff
 {variant:1}Adds (270–300) to (340–380) Physical Damage
 {variant:2}Adds (250–280) to (315–355) Physical Damage
 Adds (376–400) to (568–600) Physical Damage to Spells
@@ -138,8 +138,8 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 23, 43 Str, 43 Int
 Implicits: 2
-{variant:1}18% Chance to Block
-{variant:2}20% Chance to Block
+{variant:1}18% Chance to Block Attack Damage while wielding a Staff
+{variant:2}20% Chance to Block Attack Damage while wielding a Staff
 18% increased Cast Speed
 18% increased maximum Mana
 18% increased Area of Effect of Aura Skills
@@ -152,10 +152,10 @@ The Enmity Divine
 Imperial Staff
 League: Harbinger
 Requires Level 66, 113 Str, 113 Int
-18% Chance to Block
+18% Chance to Block Attack Damage while wielding a Staff
 Socketed Gems are supported by level 10 Life Leech
 Grants Summon Harbinger of Brutality Skill
-5% Chance to Block
+5% Chance to Block Attack Damage while wielding a Staff
 Adds (160-185) to (200-225) Physical Damage
 (30-40)% increased Critical Strike Chance
 ]],[[
@@ -165,8 +165,8 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 58, 99 Str, 99 Int
 Implicits: 2
-{variant:1}12% Chance to Block
-{variant:2}18% Chance to Block
+{variant:1}12% Chance to Block Attack Damage while wielding a Staff
+{variant:2}18% Chance to Block Attack Damage while wielding a Staff
 +2 to Level of Socketed Minion Gems
 Minions Regenerate (1.5-2.5)% Life per Second
 2% increased Minion Attack and Cast Speed per Skeleton you own
@@ -179,8 +179,8 @@ Upgrade: Upgrades to unique{Mirebough} via prophecy{Trapped in the Tower}
 Variant: Pre 2.6.0
 Variant: Current
 Implicits: 2
-{variant:1}12% Chance to Block
-{variant:2}18% Chance to Block
+{variant:1}12% Chance to Block Attack Damage while wielding a Staff
+{variant:2}18% Chance to Block Attack Damage while wielding a Staff
 Socketed Gems are Supported by level 8 Trap
 (40-50)% increased Damage
 (10-20)% increased maximum Life
@@ -190,7 +190,7 @@ Mirebough
 Gnarled Branch
 Source: Upgraded from unique{Fencoil} via prophecy{Trapped in the Tower}
 Requires Level 32
-18% Chance to Block
+18% Chance to Block Attack Damage while wielding a Staff
 Socketed Gems are Supported by Level 16 Trap
 Socketed Gems are Supported by Level 16 Cluster Trap
 Socketed Gems are Supported by Level 16 Trap and Mine Damage
@@ -214,9 +214,9 @@ Variant: Pre 3.7.0
 Variant: Current
 Requires Level 68, 113 Str, 113 Int
 Implicits: 2
-{variant:1}12% Chance to Block
-{variant:2,3}18% Chance to Block
-6% Chance to Block
+{variant:1}12% Chance to Block Attack Damage while wielding a Staff
+{variant:2,3}18% Chance to Block Attack Damage while wielding a Staff
+6% Chance to Block Attack Damage while wielding a Staff
 {variant:1,2}Adds (180-190) to (190-220) Physical Damage
 {variant:3}Adds (165-175) to (185-205) Physical Damage
 (12-16)% increased Attack Speed
@@ -229,8 +229,8 @@ Highborn Staff
 Variant: Pre 3.5.0
 Variant: Current
 Requires Level 52, 89 Str, 89 Int
-18% Chance to Block
-(12-16)% Chance to Block
+18% Chance to Block Attack Damage while wielding a Staff
+(12-16)% Chance to Block Attack Damage while wielding a Staff
 Adds (350-400) to (500-600) Fire Damage
 {variant:1}Adds (130-150) to (200-250) Fire Damage to Spells
 {variant:2}Adds (230-250) to (300-350) Fire Damage to Spells
@@ -255,8 +255,8 @@ Variant: Pre 2.6.0
 Variant: Pre 3.7.0
 Requires Level 13, 27 Str, 27 Int
 Implicits: 2
-{variant:1}12% Chance to Block
-{variant:2}18% Chance to Block
+{variant:1}12% Chance to Block Attack Damage while wielding a Staff
+{variant:2}18% Chance to Block Attack Damage while wielding a Staff
 1% increased Area of Effect of Area Skills per 20 Intelligence
 1% increased Attack Speed per 10 Dexterity
 16% increased Physical Weapon Damage per 10 Strength
@@ -269,7 +269,7 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 68, 113 Str, 113 Int
 Implicits: 2
-{variant:1}12% Chance to Block
+{variant:1}12% Chance to Block Attack Damage while wielding a Staff
 {variant:2}18% Chance to Block Attack Damage while wielding a Staff
 Socketed Gems are Supported by level 30 Greater Spell Echo
 (120-160)% increased Spell Damage
@@ -282,8 +282,8 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 18, 35 Str, 35 Int
 Implicits: 2
-{variant:1}12% Chance to Block
-{variant:2}18% Chance to Block
+{variant:1}12% Chance to Block Attack Damage while wielding a Staff
+{variant:2}18% Chance to Block Attack Damage while wielding a Staff
 +1 to Level of Socketed Fire Gems
 +1 to Level of Socketed Cold Gems
 Socketed Gems are Supported by level 5 Cold to Fire
@@ -298,8 +298,8 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 40, 35 Str, 35 Int
 Implicits: 2
-{variant:1}12% Chance to Block
-{variant:2}18% Chance to Block
+{variant:1}12% Chance to Block Attack Damage while wielding a Staff
+{variant:2}18% Chance to Block Attack Damage while wielding a Staff
 +1 to Level of Socketed Fire Gems
 +1 to Level of Socketed Cold Gems
 +2 to Level of Socketed Elemental Gems
@@ -315,8 +315,8 @@ Variant: {2_6}Pre 3.0.0
 Variant: Current
 Requires Level 60, 113 Str, 113 Int
 Implicits: 2
-{variant:1}12% Chance to Block
-{variant:2,3}18% Chance to Block
+{variant:1}12% Chance to Block Attack Damage while wielding a Staff
+{variant:2,3}18% Chance to Block Attack Damage while wielding a Staff
 +2 to Level of Socketed Fire Gems
 {variant:1,2}(30-50)% increased Spell Damage
 {variant:1,2}(20-40)% increased Fire Damage
@@ -328,7 +328,7 @@ The Searing Touch
 Long Staff
 Variant: Pre 2.0.0
 Requires Level 60, 113 Str, 113 Int
-12% Chance to Block
+12% Chance to Block Attack Damage while wielding a Staff
 +2 to Level of Socketed Fire Gems
 (30-50)% increased Spell Damage
 (20-40)% increased Fire Damage
@@ -341,8 +341,8 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 49, 85 Str, 85 Int
 Implicits: 2
-{variant:1}18% Chance to Block
-{variant:2}20% Chance to Block
+{variant:1}18% Chance to Block Attack Damage while wielding a Staff
+{variant:2}20% Chance to Block Attack Damage while wielding a Staff
 +(15-20) to All Attributes
 +(5-7)% to All Elemental Resistances
 (60-100)% increased Projectile Damage
@@ -369,8 +369,8 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 28, 51 Str, 51 Int
 Implicits: 2
-{variant:1}12% Chance to Block
-{variant:2}18% Chance to Block
+{variant:1}12% Chance to Block Attack Damage while wielding a Staff
+{variant:2}18% Chance to Block Attack Damage while wielding a Staff
 (80-100)% increased Physical Damage
 Adds (25-35) to (45-60) Cold Damage
 Adds (1-10) to (70-90) Lightning Damage
@@ -383,8 +383,8 @@ The Stormwall
 Royal Staff
 Source: Upgraded from unique{The Stormheart} via prophecy{The Storm Spire}
 Requires Level 60
-18% Chance to Block
-15% Chance to Block
+18% Chance to Block Attack Damage while wielding a Staff
+15% Chance to Block Attack Damage while wielding a Staff
 Adds (242–260) to (268–285) Physical Damage
 (20–35)% increased Critical Strike Chance
 50% of Physical Damage Converted to Cold Damage
@@ -400,8 +400,8 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 64, 113 Str, 113 Int
 Implicits: 2
-{variant:1,2}18% Chance to Block
-{variant:3}20% Chance to Block
+{variant:1,2}18% Chance to Block Attack Damage while wielding a Staff
+{variant:3}20% Chance to Block Attack Damage while wielding a Staff
 {variant:1,2}+1 to Level of Socketed Cold Gems
 {variant:3}+2 to Level of Socketed Cold Gems
 {variant:1}(40-50)% increased Spell Damage
@@ -417,8 +417,8 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 45, 78 Str, 78 Int
 Implicits: 2
-{variant:1}12% Chance to Block
-{variant:2}18% Chance to Block
+{variant:1}12% Chance to Block Attack Damage while wielding a Staff
+{variant:2}18% Chance to Block Attack Damage while wielding a Staff
 Socketed Gems are Supported by level 10 Remote Mine
 35% less Mine Damage
 (40-60)% increased Spell Damage
@@ -432,8 +432,8 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 33, 59 Str, 59 Int
 Implicits: 2
-{variant:1}12% Chance to Block
-{variant:2}18% Chance to Block
+{variant:1}12% Chance to Block Attack Damage while wielding a Staff
+{variant:2}18% Chance to Block Attack Damage while wielding a Staff
 +1 to Level of Socketed Support Gems
 Grants level 1 Icestorm Skill
 (8-12)% increased Cast Speed
@@ -447,8 +447,8 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 28, 43 Str, 43 Int
 Implicits: 2
-{variant:1}18% Chance to Block
-{variant:2}20% Chance to Block
+{variant:1}18% Chance to Block Attack Damage while wielding a Staff
+{variant:2}20% Chance to Block Attack Damage while wielding a Staff
 +1 to Level of Socketed Gems
 15% Chance to Block
 (60-80)% increased Spell Damage


### PR DESCRIPTION
"Chance to Block" was renamed to "Chance to Block Attack Damage while wielding a Staff"