### PR TITLE
Add fire dot multiplier to skill stat map

### DIFF
--- a/Data/3_0/SkillStatMap.lua
+++ b/Data/3_0/SkillStatMap.lua
@@ -631,6 +631,9 @@ return {
 ["poison_dot_multiplier_+"] = {
 	mod("DotMultiplier", "BASE", nil, 0, KeywordFlag.Poison),
 },
+["fire_dot_multiplier_+"] = {
+	mod("FireDotMultiplier", "BASE", nil),
+},
 ["active_skill_ignite_damage_+%_final"] = {
 	mod("Damage", "MORE", nil, 0, KeywordFlag.Ignite),
 },


### PR DESCRIPTION
Fixes (Vaal) Burning Arrow and Awakened Burning Damage quality not applying to calculations.