### PR TITLE
1806: Name collision between support gem and skill gem.

### DIFF
--- a/Data/3_0/Gems.lua
+++ b/Data/3_0/Gems.lua
@@ -6259,7 +6259,7 @@ return {
 		defaultLevel = 20,
 	},
 	["Metadata/Items/Gems/SupportGemBarrage"] = {
-		name = "Barrage",
+		name = "Barrage Support",
 		grantedEffectId = "SupportBarrage",
 		tags = {
 			bow = true,


### PR DESCRIPTION
#1806 Fixing name collision between support gem and skill gem.