### PR TITLE
Fix #1834 - anointing Sanctuary allocates ascendancy node

### DIFF
--- a/Classes/PassiveTree.lua
+++ b/Classes/PassiveTree.lua
@@ -197,7 +197,9 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 			self.keystoneMap[node.dn] = node
 		elseif node["not"] then
 			node.type = "Notable"
-			self.notableMap[node.dn:lower()] = node
+			if not node["ascendancyName"] then
+			    self.notableMap[node.dn:lower()] = node
+			end
 		else
 			node.type = "Normal"
 		end


### PR DESCRIPTION
This patch fixes an issue with amulet anoints where a notable shares a
name with an ascendancy node. Sanctuary is both a normal notable, and a
node in the Inquisitor ascendancy. When building the `notableMap` in
PassiveTree.lua, the ascendancy node overwrites the normal notable. This
`notableMap` is only used to look up notables for "allocates X" stats,
which cannot allocate ascendancy nodes. Accordingly, this patch checks
whether a node is part of an ascendancy before adding it to the
`notableMap`.

Test notes:
Create an amulet with "Allocates Sanctuary". Without this patch, you
will not get the benefits of Sanctuary, the notable will not be lit up
on the tree, and the Inquisitor ascendancy notable will be lit. With
this patch, the correct node will be lit, and (if you have a shield) you
will see the effects of the notable.