### PR TITLE
Barrage vs. Barrage Support distinction

### DIFF
--- a/Data/3_0/Gems.lua
+++ b/Data/3_0/Gems.lua
@@ -6301,7 +6301,7 @@ return {
 		defaultLevel = 20,
 	},
 	["Metadata/Items/Gems/SupportGemBarrage"] = {
-		name = "Barrage",
+		name = "Barrage Support",
 		grantedEffectId = "SupportBarrage",
 		tags = {
 			bow = true,

--- a/Data/3_0/Skills/sup_dex.lua
+++ b/Data/3_0/Skills/sup_dex.lua
@@ -301,7 +301,7 @@ skills["SupportArrowNovaPlus"] = {
 	},
 }
 skills["SupportBarrage"] = {
-	name = "Barrage",
+	name = "Barrage Support",
 	description = "Supports projectile attack skills that use bows or wands. Cannot support triggered skills, channelled skills, or skills that create Minions.",
 	color = 2,
 	support = true,


### PR DESCRIPTION
Allows easier distinction between Barrage and Barrage Support in Skills tab.